### PR TITLE
Update to kss 0.4.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -19,7 +19,7 @@
   },
   "license": "MIT",
   "dependencies": {
-    "kss": "~0.3.6",
+    "kss": "~0.4.0",
     "through": "~2.3.4",
     "gulp": "~3.5.2",
     "gulp-util": "~2.2.14",


### PR DESCRIPTION
0.4.0 contains backwards compatible bugfixes, so the gulp plugin should update. I tried updating locally and everything worked fine.

Kss-node is actually on version 1.0.0 now, so updating all the way should be considered. But 1.0.0 requires Node 0.10.x or later, and I don't know if anybody considers that a problem??
