### PR TITLE
Correctly resolve path to kss templates

### DIFF
--- a/index.js
+++ b/index.js
@@ -21,7 +21,7 @@ var handlebarHelpers = require('./handlebarHelpers');
 module.exports = function(opt) {
     'use strict';
     if (!opt) opt = {};
-    if (!opt.templateDirectory) opt.templateDirectory = __dirname + '/node_modules/kss/lib/template';
+    if (!opt.templateDirectory) opt.templateDirectory = path.join(path.dirname(require.resolve('kss')), 'lib', 'template');
     if (!opt.kssOpts) opt.kssOpts = {};
 
     var buffer = [];


### PR DESCRIPTION
Due to npm >3.x(?)'s flatter node_modules structure, this file wasn't resolved correctly. Using node's require.resolve to get actual file location.
